### PR TITLE
Fixed logs endpoint typing for scope

### DIFF
--- a/tap_auth0/schemas/log.py
+++ b/tap_auth0/schemas/log.py
@@ -1,4 +1,5 @@
 from singer_sdk.typing import (
+    ArrayType,
     BooleanType,
     DateTimeType,
     ObjectType,
@@ -47,7 +48,7 @@ class LogObject(CustomObject):
         Property("user_id", StringType),
         Property("user_name", StringType),
         Property("audience", StringType),
-        Property("scope", StringType),
+        Property("scope", ArrayType(StringType)),
         Property("strategy", StringType),
         Property("strategy_type", StringType),
         Property("log_id", StringType),

--- a/tap_auth0/streams.py
+++ b/tap_auth0/streams.py
@@ -169,3 +169,10 @@ class LogsStream(Auth0Stream):
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         return [] if self.log_expired else super().parse_response(response)
+    
+    def post_process(self, row: dict, context: Optional[dict] = None) -> Optional[dict]:
+        row = super().post_process(row, context)
+        scope = row.get("scope")
+        if isinstance(scope, str):
+            row.update({ "scope": scope.split() })
+        return row


### PR DESCRIPTION
The logs end point returns a field called `scope`. This can return as `string`, `array`, or `null`. This fix used the `post_process` function to make the field always be returned as an `array` for better database typing.

- Updated the logs endpoint typing on scope to always return an array.