### PR TITLE
refactor: Remove `CustomObject` implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ ignore = [
 select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-"tap_auth0/{schemas,types}/**/*" = [
+"tap_auth0/types/**/*" = [
     "D101",   # undocumented-public-class
     "N805",   # invalid-first-argument-name-for-method
 ]

--- a/tap_auth0/schemas/__init__.py
+++ b/tap_auth0/schemas/__init__.py
@@ -1,19 +1,1 @@
 """Schema definitions for tap-auth0."""
-
-from singer_sdk import typing as th
-from typing_extensions import override
-
-
-class CustomObject(th.JSONTypeHelper):
-    """Custom object."""
-
-    properties: th.PropertiesList
-
-    @th.DefaultInstanceProperty
-    @override
-    def type_dict(cls):
-        return cls.properties.to_dict()
-
-    @th.DefaultInstanceProperty
-    def schema(cls):  # noqa: D102
-        return cls.type_dict

--- a/tap_auth0/schemas/client.py
+++ b/tap_auth0/schemas/client.py
@@ -2,7 +2,6 @@
 
 from singer_sdk import typing as th
 
-from tap_auth0.schemas import CustomObject
 from tap_auth0.types.client import (
     AppTypeType,
     GrantTypeType,
@@ -13,350 +12,314 @@ from tap_auth0.types.client import (
 from tap_auth0.types.jwt_configuration import AlgType
 from tap_auth0.types.refresh_token import ExpirationTypeType, RotationTypeType
 
+_JWTConfigurationObject = th.PropertiesList(
+    th.Property("lifetime_in_seconds", th.IntegerType),
+    th.Property("secret_encoded", th.BooleanType),
+    th.Property("scopes", th.ObjectType()),
+    th.Property("alg", AlgType),
+)
 
-class _JWTConfigurationObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("lifetime_in_seconds", th.IntegerType),
-        th.Property("secret_encoded", th.BooleanType),
-        th.Property("scopes", th.ObjectType()),
-        th.Property("alg", AlgType),
-    )
 
-
-class _EncryptionKeyObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("pub", th.StringType),
-        th.Property("cert", th.StringType),
-        th.Property("subject", th.StringType),
-    )
+_EncryptionKeyObject = th.PropertiesList(
+    th.Property("pub", th.StringType),
+    th.Property("cert", th.StringType),
+    th.Property("subject", th.StringType),
+)
 
-
-class _AWSObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("principal", th.StringType),
-        th.Property("role", th.StringType),
-        th.Property("lifetime_in_seconds", th.IntegerType),
-    )
 
-
-class _AzureBlobObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("accountName", th.StringType),
-        th.Property("storageAccessKey", th.StringType),
-        th.Property("containerName", th.StringType),
-        th.Property("blobName", th.StringType),
-        th.Property("expiration", th.IntegerType),
-        th.Property("signedIdentifier", th.StringType),
-        th.Property("blob_read", th.BooleanType),
-        th.Property("blob_write", th.BooleanType),
-        th.Property("blob_delete", th.BooleanType),
-        th.Property("container_read", th.BooleanType),
-        th.Property("container_write", th.BooleanType),
-        th.Property("container_delete", th.BooleanType),
-        th.Property("container_list", th.BooleanType),
-    )
-
-
-class _AzureSBObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("namespace", th.StringType),
-        th.Property("sasKeyName", th.StringType),
-        th.Property("sasKey", th.StringType),
-        th.Property("entityPath", th.StringType),
-        th.Property("expiration", th.IntegerType),
-    )
-
-
-class _RMSObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("url", th.URIType),
-    )
-
-
-class _MSCRMObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("url", th.URIType),
-    )
-
-
-class _SlackObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("team", th.StringType),
-    )
-
-
-class _SentryObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("org_slug", th.StringType),
-        th.Property("base_url", th.URIType),
-    )
-
-
-class _EchoSignObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("domain", th.StringType),
-    )
-
-
-class _EgnyteObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("domain", th.StringType),
-    )
-
-
-class _FirebaseObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("secret", th.StringType),
-        th.Property("private_key_id", th.StringType),
-        th.Property("private_key", th.StringType),
-        th.Property("client_email", th.EmailType),
-        th.Property("lifetime_in_seconds", th.IntegerType),
-    )
-
-
-class _NewRelicObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("account", th.StringType),
-    )
-
-
-class _Office365Object(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("domain", th.StringType),
-        th.Property("connection", th.StringType),
-    )
-
-
-class _SalesforceObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("entity_id", th.URIType),
-    )
-
-
-class _SalesforceAPIObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("clientid", th.StringType),
-        th.Property("principal", th.StringType),
-        th.Property("communityName", th.StringType),
-        th.Property("community_url_section", th.StringType),
-    )
-
-
-class _SalesforceSandboxAPIObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("clientid", th.StringType),
-        th.Property("principal", th.StringType),
-        th.Property("communityName", th.StringType),
-        th.Property("community_url_section", th.StringType),
-    )
-
-
-class _SAMLPObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("mappings", th.ObjectType()),
-        th.Property("audience", th.StringType),
-        th.Property("recipient", th.StringType),
-        th.Property("createUpnClaim", th.BooleanType),
-        th.Property("mapUnknownClaimsAsIs", th.BooleanType),
-        th.Property("passthroughClaimsWithNoMapping", th.BooleanType),
-        th.Property("mapIdentities", th.BooleanType),
-        th.Property("signatureAlgorithm", th.StringType),
-        th.Property("digestAlgorithm", th.StringType),
-        th.Property("issuer", th.StringType),
-        th.Property("destination", th.StringType),
-        th.Property("lifetimeInSeconds", th.IntegerType),
-        th.Property("signResponse", th.BooleanType),
-        th.Property("nameIdentifierFormat", th.StringType),
-        th.Property("nameIdentifierProbes", th.ArrayType(th.StringType)),
-        th.Property("authnContextClassRef", th.StringType),
-    )
-
-
-class _LayerObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("providerId", th.StringType),
-        th.Property("keyId", th.StringType),
-        th.Property("privateKey", th.StringType),
-        th.Property("principal", th.StringType),
-        th.Property("expiration", th.IntegerType),
-    )
-
-
-class _SAPAPIObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("clientId", th.StringType),
-        th.Property("usernameAttribute", th.StringType),
-        th.Property("tokenEndpointUrl", th.URIType),
-        th.Property("scope", th.StringType),
-        th.Property("servicePassword", th.StringType),
-        th.Property("nameIdentifierFormat", th.StringType),
-    )
-
-
-class _SharePointObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("url", th.URIType),
-        th.Property("external_url", th.ArrayType(th.URIType)),
-    )
-
-
-class _SpringCMObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("acsurl", th.URIType),
-    )
-
-
-class _WAMSObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("masterkey", th.StringType),
-    )
-
-
-class _ZendeskObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("accountName", th.StringType),
-    )
-
-
-class _ZoomObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("account", th.StringType),
-    )
-
-
-class _SSOIntegrationObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("name", th.StringType),
-        th.Property("version", th.StringType),
-    )
-
-
-class _AddonsObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("aws", _AWSObject),
-        th.Property("azure_blob", _AzureBlobObject),
-        th.Property("azure_sb", _AzureSBObject),
-        th.Property("rms", _RMSObject),
-        th.Property("mscrm", _MSCRMObject),
-        th.Property("slack", _SlackObject),
-        th.Property("sentry", _SentryObject),
-        th.Property("box", th.ObjectType()),
-        th.Property("cloudbees", th.ObjectType()),
-        th.Property("concur", th.ObjectType()),
-        th.Property("dropbox", th.ObjectType()),
-        th.Property("echosign", _EchoSignObject),
-        th.Property("egnyte", _EgnyteObject),
-        th.Property("firebase", _FirebaseObject),
-        th.Property("newrelic", _NewRelicObject),
-        th.Property("office365", _Office365Object),
-        th.Property("salesforce", _SalesforceObject),
-        th.Property("salesforce_api", _SalesforceAPIObject),
-        th.Property("salesforce_sandbox_api", _SalesforceSandboxAPIObject),
-        th.Property("samlp", _SAMLPObject),
-        th.Property("layer", _LayerObject),
-        th.Property("sap_api", _SAPAPIObject),
-        th.Property("sharepoint", _SharePointObject),
-        th.Property("springcm", _SpringCMObject),
-        th.Property("wams", _WAMSObject),
-        th.Property("wsfed", th.ObjectType()),
-        th.Property("zendesk", _ZendeskObject),
-        th.Property("zoom", _ZoomObject),
-        th.Property("sso_integration", _SSOIntegrationObject),
-    )
-
-
-class _AndroidObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("app_package_name", th.StringType),
-        th.Property("sha256_cert_fingerprints", th.ArrayType(th.StringType)),
-    )
-
-
-class _iOSObject(CustomObject):  # noqa: N801
-    properties = th.PropertiesList(
-        th.Property("team_id", th.StringType),
-        th.Property("app_bundle_identifier", th.StringType),
-    )
-
-
-class _MobileObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("android", _AndroidObject),
-        th.Property("ios", _iOSObject),
-    )
-
-
-class _AppleObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("enabled", th.BooleanType),
-    )
-
-
-class _FacebookObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("enabled", th.BooleanType),
-    )
-
-
-class _NativeSocialLoginObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("apple", _AppleObject),
-        th.Property("facebook", _FacebookObject),
-    )
-
-
-class _RefreshTokenObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("rotation_type", RotationTypeType),
-        th.Property("expiration_type", ExpirationTypeType),
-        th.Property("leeway", th.IntegerType),
-        th.Property("token_lifetime", th.IntegerType),
-        th.Property("infinite_token_lifetime", th.BooleanType),
-        th.Property("idle_token_lifetime", th.IntegerType),
-        th.Property("infinite_idle_token_lifetime", th.BooleanType),
-    )
-
-
-class ClientObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("client_id", th.StringType),
-        th.Property("tenant", th.StringType),
-        th.Property("name", th.StringType),
-        th.Property("description", th.StringType),
-        th.Property("global", th.BooleanType),
-        th.Property("client_secret", th.StringType),
-        th.Property("app_type", AppTypeType),
-        th.Property("logo_uri", th.URIType),
-        th.Property("is_first_party", th.BooleanType),
-        th.Property("oidc_conformant", th.BooleanType),
-        th.Property("callbacks", th.ArrayType(th.URIType)),
-        th.Property("allowed_origins", th.ArrayType(th.URIType)),
-        th.Property("web_origins", th.ArrayType(th.URIType)),
-        th.Property("client_aliases", th.ArrayType(th.StringType)),
-        th.Property("allowed_clients", th.ArrayType(th.StringType)),
-        th.Property("allowed_logout_urls", th.ArrayType(th.URIType)),
-        th.Property("grant_types", th.ArrayType(GrantTypeType)),
-        th.Property("jwt_configuration", _JWTConfigurationObject),
-        th.Property("signing_keys", th.ArrayType(th.ObjectType())),
-        th.Property("encryption_key", _EncryptionKeyObject),
-        th.Property("sso", th.BooleanType),
-        th.Property("sso_disabled", th.BooleanType),
-        th.Property("cross_origin_auth", th.BooleanType),
-        th.Property("cross_origin_loc", th.URIType),
-        th.Property("custom_login_page_on", th.BooleanType),
-        th.Property("custom_login_page", th.StringType),
-        th.Property("custom_login_page_preview", th.StringType),
-        th.Property("form_template", th.StringType),
-        th.Property("addons", _AddonsObject),
-        th.Property("token_endpoint_auth_method", TokenEndpointAuthMethodType),
-        th.Property("client_metadata", th.ObjectType()),
-        th.Property("mobile", _MobileObject),
-        th.Property("initiate_login_uri", th.URIType),
-        th.Property("native_social_login", _NativeSocialLoginObject),
-        th.Property("refresh_token", _RefreshTokenObject),
-        th.Property("organization_usage", OrganizationUsageType),
-        th.Property("organization_require_behavior", OrganizationRequireBehaviourType),
-        th.Property("is_token_endpoint_ip_header_trusted", th.BooleanType),
-        th.Property("callback_url_template", th.BooleanType),
-        th.Property("owners", th.ArrayType(th.StringType)),
-    )
+_AWSObject = th.PropertiesList(
+    th.Property("principal", th.StringType),
+    th.Property("role", th.StringType),
+    th.Property("lifetime_in_seconds", th.IntegerType),
+)
+
+
+_AzureBlobObject = th.PropertiesList(
+    th.Property("accountName", th.StringType),
+    th.Property("storageAccessKey", th.StringType),
+    th.Property("containerName", th.StringType),
+    th.Property("blobName", th.StringType),
+    th.Property("expiration", th.IntegerType),
+    th.Property("signedIdentifier", th.StringType),
+    th.Property("blob_read", th.BooleanType),
+    th.Property("blob_write", th.BooleanType),
+    th.Property("blob_delete", th.BooleanType),
+    th.Property("container_read", th.BooleanType),
+    th.Property("container_write", th.BooleanType),
+    th.Property("container_delete", th.BooleanType),
+    th.Property("container_list", th.BooleanType),
+)
+
+
+_AzureSBObject = th.PropertiesList(
+    th.Property("namespace", th.StringType),
+    th.Property("sasKeyName", th.StringType),
+    th.Property("sasKey", th.StringType),
+    th.Property("entityPath", th.StringType),
+    th.Property("expiration", th.IntegerType),
+)
+
+
+_RMSObject = th.PropertiesList(
+    th.Property("url", th.URIType),
+)
+
+
+_MSCRMObject = th.PropertiesList(
+    th.Property("url", th.URIType),
+)
+
+
+_SlackObject = th.PropertiesList(
+    th.Property("team", th.StringType),
+)
+
+
+_SentryObject = th.PropertiesList(
+    th.Property("org_slug", th.StringType),
+    th.Property("base_url", th.URIType),
+)
+
+
+_EchoSignObject = th.PropertiesList(
+    th.Property("domain", th.StringType),
+)
+
+
+_EgnyteObject = th.PropertiesList(
+    th.Property("domain", th.StringType),
+)
+
+
+_FirebaseObject = th.PropertiesList(
+    th.Property("secret", th.StringType),
+    th.Property("private_key_id", th.StringType),
+    th.Property("private_key", th.StringType),
+    th.Property("client_email", th.EmailType),
+    th.Property("lifetime_in_seconds", th.IntegerType),
+)
+
+
+_NewRelicObject = th.PropertiesList(
+    th.Property("account", th.StringType),
+)
+
+
+_Office365Object = th.PropertiesList(
+    th.Property("domain", th.StringType),
+    th.Property("connection", th.StringType),
+)
+
+
+_SalesforceObject = th.PropertiesList(
+    th.Property("entity_id", th.URIType),
+)
+
+
+_SalesforceAPIObject = th.PropertiesList(
+    th.Property("clientid", th.StringType),
+    th.Property("principal", th.StringType),
+    th.Property("communityName", th.StringType),
+    th.Property("community_url_section", th.StringType),
+)
+
+
+_SalesforceSandboxAPIObject = th.PropertiesList(
+    th.Property("clientid", th.StringType),
+    th.Property("principal", th.StringType),
+    th.Property("communityName", th.StringType),
+    th.Property("community_url_section", th.StringType),
+)
+
+
+_SAMLPObject = th.PropertiesList(
+    th.Property("mappings", th.ObjectType()),
+    th.Property("audience", th.StringType),
+    th.Property("recipient", th.StringType),
+    th.Property("createUpnClaim", th.BooleanType),
+    th.Property("mapUnknownClaimsAsIs", th.BooleanType),
+    th.Property("passthroughClaimsWithNoMapping", th.BooleanType),
+    th.Property("mapIdentities", th.BooleanType),
+    th.Property("signatureAlgorithm", th.StringType),
+    th.Property("digestAlgorithm", th.StringType),
+    th.Property("issuer", th.StringType),
+    th.Property("destination", th.StringType),
+    th.Property("lifetimeInSeconds", th.IntegerType),
+    th.Property("signResponse", th.BooleanType),
+    th.Property("nameIdentifierFormat", th.StringType),
+    th.Property("nameIdentifierProbes", th.ArrayType(th.StringType)),
+    th.Property("authnContextClassRef", th.StringType),
+)
+
+
+_LayerObject = th.PropertiesList(
+    th.Property("providerId", th.StringType),
+    th.Property("keyId", th.StringType),
+    th.Property("privateKey", th.StringType),
+    th.Property("principal", th.StringType),
+    th.Property("expiration", th.IntegerType),
+)
+
+
+_SAPAPIObject = th.PropertiesList(
+    th.Property("clientId", th.StringType),
+    th.Property("usernameAttribute", th.StringType),
+    th.Property("tokenEndpointUrl", th.URIType),
+    th.Property("scope", th.StringType),
+    th.Property("servicePassword", th.StringType),
+    th.Property("nameIdentifierFormat", th.StringType),
+)
+
+
+_SharePointObject = th.PropertiesList(
+    th.Property("url", th.URIType),
+    th.Property("external_url", th.ArrayType(th.URIType)),
+)
+
+
+_SpringCMObject = th.PropertiesList(
+    th.Property("acsurl", th.URIType),
+)
+
+
+_WAMSObject = th.PropertiesList(
+    th.Property("masterkey", th.StringType),
+)
+
+
+_ZendeskObject = th.PropertiesList(
+    th.Property("accountName", th.StringType),
+)
+
+
+_ZoomObject = th.PropertiesList(
+    th.Property("account", th.StringType),
+)
+
+
+_SSOIntegrationObject = th.PropertiesList(
+    th.Property("name", th.StringType),
+    th.Property("version", th.StringType),
+)
+
+
+_AddonsObject = th.PropertiesList(
+    th.Property("aws", _AWSObject),
+    th.Property("azure_blob", _AzureBlobObject),
+    th.Property("azure_sb", _AzureSBObject),
+    th.Property("rms", _RMSObject),
+    th.Property("mscrm", _MSCRMObject),
+    th.Property("slack", _SlackObject),
+    th.Property("sentry", _SentryObject),
+    th.Property("box", th.ObjectType()),
+    th.Property("cloudbees", th.ObjectType()),
+    th.Property("concur", th.ObjectType()),
+    th.Property("dropbox", th.ObjectType()),
+    th.Property("echosign", _EchoSignObject),
+    th.Property("egnyte", _EgnyteObject),
+    th.Property("firebase", _FirebaseObject),
+    th.Property("newrelic", _NewRelicObject),
+    th.Property("office365", _Office365Object),
+    th.Property("salesforce", _SalesforceObject),
+    th.Property("salesforce_api", _SalesforceAPIObject),
+    th.Property("salesforce_sandbox_api", _SalesforceSandboxAPIObject),
+    th.Property("samlp", _SAMLPObject),
+    th.Property("layer", _LayerObject),
+    th.Property("sap_api", _SAPAPIObject),
+    th.Property("sharepoint", _SharePointObject),
+    th.Property("springcm", _SpringCMObject),
+    th.Property("wams", _WAMSObject),
+    th.Property("wsfed", th.ObjectType()),
+    th.Property("zendesk", _ZendeskObject),
+    th.Property("zoom", _ZoomObject),
+    th.Property("sso_integration", _SSOIntegrationObject),
+)
+
+
+_AndroidObject = th.PropertiesList(
+    th.Property("app_package_name", th.StringType),
+    th.Property("sha256_cert_fingerprints", th.ArrayType(th.StringType)),
+)
+
+
+_iOSObject = th.PropertiesList(  # noqa: N816
+    th.Property("team_id", th.StringType),
+    th.Property("app_bundle_identifier", th.StringType),
+)
+
+
+_MobileObject = th.PropertiesList(
+    th.Property("android", _AndroidObject),
+    th.Property("ios", _iOSObject),
+)
+
+
+_AppleObject = th.PropertiesList(
+    th.Property("enabled", th.BooleanType),
+)
+
+
+_FacebookObject = th.PropertiesList(
+    th.Property("enabled", th.BooleanType),
+)
+
+
+_NativeSocialLoginObject = th.PropertiesList(
+    th.Property("apple", _AppleObject),
+    th.Property("facebook", _FacebookObject),
+)
+
+
+_RefreshTokenObject = th.PropertiesList(
+    th.Property("rotation_type", RotationTypeType),
+    th.Property("expiration_type", ExpirationTypeType),
+    th.Property("leeway", th.IntegerType),
+    th.Property("token_lifetime", th.IntegerType),
+    th.Property("infinite_token_lifetime", th.BooleanType),
+    th.Property("idle_token_lifetime", th.IntegerType),
+    th.Property("infinite_idle_token_lifetime", th.BooleanType),
+)
+
+
+ClientObject = th.PropertiesList(
+    th.Property("client_id", th.StringType),
+    th.Property("tenant", th.StringType),
+    th.Property("name", th.StringType),
+    th.Property("description", th.StringType),
+    th.Property("global", th.BooleanType),
+    th.Property("client_secret", th.StringType),
+    th.Property("app_type", AppTypeType),
+    th.Property("logo_uri", th.URIType),
+    th.Property("is_first_party", th.BooleanType),
+    th.Property("oidc_conformant", th.BooleanType),
+    th.Property("callbacks", th.ArrayType(th.URIType)),
+    th.Property("allowed_origins", th.ArrayType(th.URIType)),
+    th.Property("web_origins", th.ArrayType(th.URIType)),
+    th.Property("client_aliases", th.ArrayType(th.StringType)),
+    th.Property("allowed_clients", th.ArrayType(th.StringType)),
+    th.Property("allowed_logout_urls", th.ArrayType(th.URIType)),
+    th.Property("grant_types", th.ArrayType(GrantTypeType)),
+    th.Property("jwt_configuration", _JWTConfigurationObject),
+    th.Property("signing_keys", th.ArrayType(th.ObjectType())),
+    th.Property("encryption_key", _EncryptionKeyObject),
+    th.Property("sso", th.BooleanType),
+    th.Property("sso_disabled", th.BooleanType),
+    th.Property("cross_origin_auth", th.BooleanType),
+    th.Property("cross_origin_loc", th.URIType),
+    th.Property("custom_login_page_on", th.BooleanType),
+    th.Property("custom_login_page", th.StringType),
+    th.Property("custom_login_page_preview", th.StringType),
+    th.Property("form_template", th.StringType),
+    th.Property("addons", _AddonsObject),
+    th.Property("token_endpoint_auth_method", TokenEndpointAuthMethodType),
+    th.Property("client_metadata", th.ObjectType()),
+    th.Property("mobile", _MobileObject),
+    th.Property("initiate_login_uri", th.URIType),
+    th.Property("native_social_login", _NativeSocialLoginObject),
+    th.Property("refresh_token", _RefreshTokenObject),
+    th.Property("organization_usage", OrganizationUsageType),
+    th.Property("organization_require_behavior", OrganizationRequireBehaviourType),
+    th.Property("is_token_endpoint_ip_header_trusted", th.BooleanType),
+    th.Property("callback_url_template", th.BooleanType),
+    th.Property("owners", th.ArrayType(th.StringType)),
+)

--- a/tap_auth0/schemas/log.py
+++ b/tap_auth0/schemas/log.py
@@ -2,56 +2,51 @@
 
 from singer_sdk import typing as th
 
-from tap_auth0.schemas import CustomObject
 from tap_auth0.types import IPType
 from tap_auth0.types.location_info import ContinentCodeType
 from tap_auth0.types.log import LogTypeType
 
-
-class _LocationInfoObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("country_code", th.StringType),
-        th.Property("country_code3", th.StringType),
-        th.Property("country_name", th.StringType),
-        th.Property("city_name", th.StringType),
-        th.Property("latitude", th.StringType),
-        th.Property("longitude", th.StringType),
-        th.Property("time_zone", th.StringType),
-        th.Property("continent_code", ContinentCodeType),
-    )
+_LocationInfoObject = th.PropertiesList(
+    th.Property("country_code", th.StringType),
+    th.Property("country_code3", th.StringType),
+    th.Property("country_name", th.StringType),
+    th.Property("city_name", th.StringType),
+    th.Property("latitude", th.StringType),
+    th.Property("longitude", th.StringType),
+    th.Property("time_zone", th.StringType),
+    th.Property("continent_code", ContinentCodeType),
+)
 
 
-class _Auth0ClientObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("name", th.StringType),
-        th.Property("version", th.StringType),
-    )
+_Auth0ClientObject = th.PropertiesList(
+    th.Property("name", th.StringType),
+    th.Property("version", th.StringType),
+)
 
 
-class LogObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("date", th.DateTimeType),
-        th.Property("type", LogTypeType),
-        th.Property("description", th.StringType),
-        th.Property("connection", th.StringType),
-        th.Property("connection_id", th.StringType),
-        th.Property("client_id", th.StringType),
-        th.Property("client_name", th.StringType),
-        th.Property("ip", IPType),
-        th.Property("hostname", th.StringType),
-        th.Property("user_id", th.StringType),
-        th.Property("user_name", th.StringType),
-        th.Property("audience", th.StringType),
-        th.Property("scope", th.ArrayType(th.StringType)),
-        th.Property("strategy", th.StringType),
-        th.Property("strategy_type", th.StringType),
-        th.Property("log_id", th.StringType),
-        th.Property("isMobile", th.BooleanType),
-        th.Property("details", th.ObjectType()),
-        th.Property("user_agent", th.StringType),
-        th.Property("location_info", _LocationInfoObject),
-        th.Property("auth0_client", _Auth0ClientObject),
-        th.Property("_id", th.StringType),
-        th.Property("session_connection", th.StringType),
-        th.Property("client_ip", IPType),
-    )
+LogObject = th.PropertiesList(
+    th.Property("date", th.DateTimeType),
+    th.Property("type", LogTypeType),
+    th.Property("description", th.StringType),
+    th.Property("connection", th.StringType),
+    th.Property("connection_id", th.StringType),
+    th.Property("client_id", th.StringType),
+    th.Property("client_name", th.StringType),
+    th.Property("ip", IPType),
+    th.Property("hostname", th.StringType),
+    th.Property("user_id", th.StringType),
+    th.Property("user_name", th.StringType),
+    th.Property("audience", th.StringType),
+    th.Property("scope", th.ArrayType(th.StringType)),
+    th.Property("strategy", th.StringType),
+    th.Property("strategy_type", th.StringType),
+    th.Property("log_id", th.StringType),
+    th.Property("isMobile", th.BooleanType),
+    th.Property("details", th.ObjectType()),
+    th.Property("user_agent", th.StringType),
+    th.Property("location_info", _LocationInfoObject),
+    th.Property("auth0_client", _Auth0ClientObject),
+    th.Property("_id", th.StringType),
+    th.Property("session_connection", th.StringType),
+    th.Property("client_ip", IPType),
+)

--- a/tap_auth0/schemas/user.py
+++ b/tap_auth0/schemas/user.py
@@ -2,43 +2,39 @@
 
 from singer_sdk import typing as th
 
-from tap_auth0.schemas import CustomObject
 from tap_auth0.types import IPType
 
-
-class _IdentityObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("connection", th.StringType),
-        th.Property("user_id", th.StringType),
-        th.Property("provider", th.StringType),
-        th.Property("isSocial", th.BooleanType),
-        th.Property("profileData", th.ObjectType()),
-    )
+_IdentityObject = th.PropertiesList(
+    th.Property("connection", th.StringType),
+    th.Property("user_id", th.StringType),
+    th.Property("provider", th.StringType),
+    th.Property("isSocial", th.BooleanType),
+    th.Property("profileData", th.ObjectType()),
+)
 
 
-class UserObject(CustomObject):
-    properties = th.PropertiesList(
-        th.Property("user_id", th.StringType),
-        th.Property("email", th.EmailType),
-        th.Property("email_verified", th.BooleanType),
-        th.Property("username", th.StringType),
-        th.Property("phone_number", th.StringType),
-        th.Property("phone_verified", th.BooleanType),
-        th.Property("created_at", th.DateTimeType),
-        th.Property("updated_at", th.DateTimeType),
-        th.Property("identities", th.ArrayType(_IdentityObject)),
-        th.Property("app_metadata", th.ObjectType()),
-        th.Property("user_metadata", th.ObjectType()),
-        th.Property("picture", th.URIType),
-        th.Property("name", th.StringType),
-        th.Property("nickname", th.StringType),
-        th.Property("multifactor", th.ArrayType(th.StringType)),
-        th.Property("last_ip", IPType),
-        th.Property("last_login", th.DateTimeType),
-        th.Property("logins_count", th.IntegerType),
-        th.Property("blocked", th.BooleanType),
-        th.Property("given_name", th.StringType),
-        th.Property("family_name", th.StringType),
-        th.Property("last_password_reset", th.DateTimeType),
-        th.Property("locale", th.StringType),
-    )
+UserObject = th.PropertiesList(
+    th.Property("user_id", th.StringType),
+    th.Property("email", th.EmailType),
+    th.Property("email_verified", th.BooleanType),
+    th.Property("username", th.StringType),
+    th.Property("phone_number", th.StringType),
+    th.Property("phone_verified", th.BooleanType),
+    th.Property("created_at", th.DateTimeType),
+    th.Property("updated_at", th.DateTimeType),
+    th.Property("identities", th.ArrayType(_IdentityObject)),
+    th.Property("app_metadata", th.ObjectType()),
+    th.Property("user_metadata", th.ObjectType()),
+    th.Property("picture", th.URIType),
+    th.Property("name", th.StringType),
+    th.Property("nickname", th.StringType),
+    th.Property("multifactor", th.ArrayType(th.StringType)),
+    th.Property("last_ip", IPType),
+    th.Property("last_login", th.DateTimeType),
+    th.Property("logins_count", th.IntegerType),
+    th.Property("blocked", th.BooleanType),
+    th.Property("given_name", th.StringType),
+    th.Property("family_name", th.StringType),
+    th.Property("last_password_reset", th.DateTimeType),
+    th.Property("locale", th.StringType),
+)

--- a/tap_auth0/streams.py
+++ b/tap_auth0/streams.py
@@ -24,7 +24,7 @@ class UsersStream(Auth0Stream):
 
     name = "stream_auth0_users"
     primary_keys = ("user_id",)
-    schema = UserObject.schema
+    schema = UserObject.to_dict()
     url_base = ""
 
     @property
@@ -123,7 +123,7 @@ class ClientsStream(Auth0Stream):
     name = "stream_auth0_clients"
     path = "/clients"
     primary_keys = ("client_id",)
-    schema = ClientObject.schema
+    schema = ClientObject.to_dict()
 
 
 class LogsStream(Auth0Stream):
@@ -133,7 +133,7 @@ class LogsStream(Auth0Stream):
     path = "/logs"
     primary_keys = ("log_id",)
     replication_key = "log_id"
-    schema = LogObject.schema
+    schema = LogObject.to_dict()
     log_expired = False
 
     @override


### PR DESCRIPTION
Current implementation is unnecessary and overly complicated - can be achieved with native SDK functionality.