### PR TITLE
fix: Invalid `IPType` schema

### DIFF
--- a/tap_auth0/types/__init__.py
+++ b/tap_auth0/types/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import itertools
+
 import singer_sdk.typing as th
 from typing_extensions import override
 
@@ -15,6 +17,6 @@ class IPType(th.JSONTypeHelper):
         type_dicts: list[dict] = [ip_type.type_dict for ip_type in cls.ip_types]
 
         return {
-            "type": [td.pop("type") for td in type_dicts],
+            "type": list(set(itertools.chain(*[td.pop("type") for td in type_dicts]))),
             "oneOf": type_dicts,
         }


### PR DESCRIPTION
Previously was producing a schema like:

```json
{
  "ip": {
      "type": [
        ["string"],
        ["string"]
      ]
  }
}
```

Now produces:

```json
{
  "ip": {
      "type": [
        "string",
        "null"
      ]
  }
}
```