### PR TITLE
fix: Error with IP value valid against multiple schemas

### DIFF
--- a/tap_auth0/schemas/__init__.py
+++ b/tap_auth0/schemas/__init__.py
@@ -2,6 +2,4 @@
 
 from singer_sdk import typing as th
 
-IPType = th.CustomType(
-    th.StringType().to_dict() | th.OneOf(th.IPv4Type, th.IPv6Type).to_dict()
-)
+IPType = th.OneOf(th.IPv4Type, th.IPv6Type, th.CustomType({"type": ["null"]}))


### PR DESCRIPTION
When dealing with non-`null` IP values, validation would previously fail matching against multiple schemas.