### PR TITLE
[MEL-499] fix: Correct schema types for `location_info.latitude`/`location_info.longitude`

### DIFF
--- a/tap_auth0/schemas/log.py
+++ b/tap_auth0/schemas/log.py
@@ -7,8 +7,8 @@ _LocationInfoObject = th.PropertiesList(
     th.Property("country_code3", th.StringType),
     th.Property("country_name", th.StringType),
     th.Property("city_name", th.StringType),
-    th.Property("latitude", th.StringType),
-    th.Property("longitude", th.StringType),
+    th.Property("latitude", th.NumberType),
+    th.Property("longitude", th.NumberType),
     th.Property("time_zone", th.StringType),
     th.Property(
         "continent_code",


### PR DESCRIPTION
snowflake fails on handling the lat long for string datatype

- https://auth0.com/docs/api/management/v2/logs/get-logs#response-one-of-0-items-location-info-latitude
- https://auth0.com/docs/api/management/v2/logs/get-logs#response-one-of-0-items-location-info-longitude